### PR TITLE
Properly initialize `sndfile` member to avoid random segmentation faults

### DIFF
--- a/SampleBuf.h
+++ b/SampleBuf.h
@@ -59,7 +59,7 @@ public:
 private:
 	// private libsndfile wrappers
     int getSamples(const char* file, float *buf, int channel, int startFrame, int endFrame);
-	SNDFILE *sndfile ;
+	SNDFILE *sndfile = NULL;
 	SF_INFO sfinfo ;
 };
 


### PR DESCRIPTION
This wold occasionally fail in the constructor. The underlying reason is that the constructor is in turn calling `openSF()` and the first thing this does is `sf_close(sndfile);`. Now, previously `sndfile` was not  initialized, so it would contain random gibberish. When the random gibberish was different from `NULL`, then the call to `sf_close(sndfile)` would cause a segmentation fault.

This patch properly initializes it to `NULL`.